### PR TITLE
[Refactor] 토큰 핸들링 로직 수정

### DIFF
--- a/src/main/java/com/bobhub/_core/config/SecurityConfig.java
+++ b/src/main/java/com/bobhub/_core/config/SecurityConfig.java
@@ -32,8 +32,7 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     ObjectMapper objectMapper = new ObjectMapper();
 
-    http
-        .cors(withDefaults())
+    http.cors(withDefaults())
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
@@ -41,14 +40,16 @@ public class SecurityConfig {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .exceptionHandling(
             e ->
-                e.accessDeniedHandler((request, response, accessDeniedException) -> {
-                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                            response.getWriter().write(
-                                    objectMapper.writeValueAsString(ApiUtils.error(ErrorCode.ACCESS_DENIED))
-                            );
-                        })
-        )
+                e.accessDeniedHandler(
+                    (request, response, accessDeniedException) -> {
+                      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                      response
+                          .getWriter()
+                          .write(
+                              objectMapper.writeValueAsString(
+                                  ApiUtils.error(ErrorCode.ACCESS_DENIED)));
+                    }))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(

--- a/src/main/java/com/bobhub/_core/config/SecurityConfig.java
+++ b/src/main/java/com/bobhub/_core/config/SecurityConfig.java
@@ -2,12 +2,17 @@ package com.bobhub._core.config;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
+import com.bobhub._core.exception.ErrorCode;
 import com.bobhub._core.jwt.JwtAuthenticationFilter;
 import com.bobhub._core.jwt.JwtTokenProvider;
+import com.bobhub._core.utils.ApiUtils;
 import com.bobhub.auth.service.TokenBlacklistService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,30 +26,38 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final JwtTokenProvider jwtTokenProvider;
-  private final TokenBlacklistService tokenBlacklistService; // 블랙리스트 서비스 주입
+  private final TokenBlacklistService tokenBlacklistService;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+
     http
-        // CSRF, form login, HTTP basic 인증 비활성화
         .cors(withDefaults())
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-
-        // 세션 관리를 STATELESS(상태 없음)으로 설정
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-        // 요청 경로별 인가 설정
+        .exceptionHandling(
+            e ->
+                e.accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(ApiUtils.error(ErrorCode.ACCESS_DENIED))
+                            );
+                        })
+        )
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(
                         "/",
                         "/login",
                         "/error",
-                        "/api/oauth/**", // Google ID 토큰 로그인을 위한 새 엔드포인트
-                        "/api/actuator/prometheus", // Prometheus 메트릭 수집 엔드포인트
+                        "/api/oauth/**",
+                        "/api/refresh",
+                        "/api/actuator/prometheus",
                         "/document/**",
                         "/css/**",
                         "/images/**",
@@ -52,9 +65,6 @@ public class SecurityConfig {
                     .permitAll()
                     .anyRequest()
                     .authenticated())
-
-        // 직접 만든 JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
-        // 필터 생성 시 tokenBlacklistService를 전달
         .addFilterBefore(
             new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistService),
             UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/bobhub/_core/exception/ErrorCode.java
+++ b/src/main/java/com/bobhub/_core/exception/ErrorCode.java
@@ -8,28 +8,29 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
   // 400 BAD_REQUEST
-  INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
-  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
-  METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 인자 값입니다."),
+  INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다.", "AUTH_002"),
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다.", "COMMON_001"),
+  METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 인자 값입니다.", "COMMON_002"),
 
   // 401 UNAUTHORIZED
-  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-  TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.", "AUTH_001"),
+  TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다.", "AUTH_003"),
 
   // 403 FORBIDDEN
-  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", "AUTH_004"),
 
   // 404 NOT_FOUND
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-  RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
-  COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.", "USER_001"),
+  RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다.", "POST_001"),
+  COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.", "COMMENT_001"),
 
   // 409 CONFLICT
-  DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT, "데이터 무결성 위반입니다."),
+  DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT, "데이터 무결성 위반입니다.", "COMMON_003"),
 
   // 500 INTERNAL_SERVER_ERROR
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다.");
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다.", "SERVER_001");
 
   private final HttpStatus status;
   private final String message;
+  private final String code;
 }

--- a/src/main/java/com/bobhub/_core/exception/SuccessCode.java
+++ b/src/main/java/com/bobhub/_core/exception/SuccessCode.java
@@ -8,11 +8,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessCode {
   // 200 OK
-  OK(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+  OK(HttpStatus.OK, "요청이 성공적으로 처리되었습니다.", "SUCCESS_001"),
 
   // 201 CREATED
-  CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다.");
+  CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다.", "SUCCESS_002");
 
   private final HttpStatus status;
   private final String message;
+  private final String code;
 }

--- a/src/main/java/com/bobhub/_core/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/bobhub/_core/jwt/JwtTokenProvider.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
   private final Key key;
-  
+
   private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
   private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
 

--- a/src/main/java/com/bobhub/_core/utils/ApiUtils.java
+++ b/src/main/java/com/bobhub/_core/utils/ApiUtils.java
@@ -1,17 +1,22 @@
 package com.bobhub._core.utils;
 
+import com.bobhub._core.exception.ErrorCode;
+import com.bobhub._core.exception.SuccessCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 public class ApiUtils {
 
-  public static <T> ApiResult<T> success(T response) {
-    return new ApiResult<>(true, response, null);
+  public static <T> ApiResult<T> success(T response, SuccessCode successCode) {
+    return new ApiResult<>(true, response, successCode.getMessage(), successCode.getCode());
   }
 
-  public static ApiResult<?> error(String message, HttpStatus status) {
-    return new ApiResult<>(false, null, new ApiError(message, status.value()));
+  public static ApiResult<?> success(SuccessCode successCode) {
+    return new ApiResult<>(true, null, successCode.getMessage(), successCode.getCode());
+  }
+
+  public static ApiResult<?> error(ErrorCode errorCode) {
+    return new ApiResult<>(false, null, errorCode.getMessage(), errorCode.getCode());
   }
 
   @Getter
@@ -19,13 +24,7 @@ public class ApiUtils {
   public static class ApiResult<T> {
     private final boolean success;
     private final T response;
-    private final ApiError error;
-  }
-
-  @Getter
-  @AllArgsConstructor
-  public static class ApiError {
     private final String message;
-    private final int status;
+    private final String code;
   }
 }

--- a/src/main/java/com/bobhub/auth/controller/AuthController.java
+++ b/src/main/java/com/bobhub/auth/controller/AuthController.java
@@ -7,8 +7,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,8 +29,6 @@ public class AuthController {
             .path("/")
             .maxAge(maxAge)
             .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
             .build();
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
@@ -41,10 +41,10 @@ public class AuthController {
       LoginResponse loginResponse = authService.loginWithGoogle(code);
 
       // 1. AccessToken을 HttpOnly 쿠키에 설정
-      addCookie(response, "accessToken", loginResponse.getAccessToken(), 3600); // 1시간
+      addCookie(response, "accessToken", loginResponse.getAccessToken(), 60 * 60 * 24); // 1일
 
       // 2. RefreshToken을 HttpOnly 쿠키에 설정
-      addCookie(response, "refreshToken", loginResponse.getRefreshToken(), 604800); // 7일
+      addCookie(response, "refreshToken", loginResponse.getRefreshToken(), 60 * 60 * 24 * 7); // 7일
 
       // 3. 응답 본문에는 사용자 정보만 전달
       return ResponseEntity.ok(loginResponse.getUserInfo());
@@ -64,5 +64,17 @@ public class AuthController {
     addCookie(res, "accessToken", null, 0);
     addCookie(res, "refreshToken", null, 0);
     return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/refresh")
+  public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response) {
+    try {
+      String newAccessToken = authService.refreshAccessToken(request);
+      addCookie(response, "accessToken", newAccessToken, 60 * 60 * 24); // 1일
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body("Unable to refresh token: " + e.getMessage());
+    }
   }
 }

--- a/src/main/java/com/bobhub/auth/controller/AuthController.java
+++ b/src/main/java/com/bobhub/auth/controller/AuthController.java
@@ -25,11 +25,7 @@ public class AuthController {
 
   private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
     ResponseCookie cookie =
-        ResponseCookie.from(name, value)
-            .path("/")
-            .maxAge(maxAge)
-            .httpOnly(true)
-            .build();
+        ResponseCookie.from(name, value).path("/").maxAge(maxAge).httpOnly(true).build();
     response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 쿠키 내 토큰 저장 기한과 토큰 만료 기간 수정
2. 토큰 만료 / 유효성 검사를 위한 security, jwt 설정 수정

<br>

## 📌Issue
> 닫을 issue 번호 : resolved #49

<br>

## 🩼Branch
> 반영 branch refactor-49 -> dev

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 액세스 토큰 재발급용 GET /api/refresh 엔드포인트 추가. 리프레시 토큰로 새 액세스 토큰을 발급해 HttpOnly 쿠키(1일)로 설정.
  - 에러 응답을 JSON(code, message) 형태로 표준화하고, 접근 거부 시 403 JSON 반환.
  - JWT 오류에 대해 만료/유효하지 않음/미제공 등 구체적 코드와 메시지 제공.
  - 리프레시 토큰 유효기간을 7일로 연장.
  - 인증 제외 경로를 /api/refresh 및 /api/oauth/* 로 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->